### PR TITLE
[IR] RSUW: change a user's uselist[num] to val while manage use-def chain

### DIFF
--- a/backend/gir.hpp
+++ b/backend/gir.hpp
@@ -14,5 +14,3 @@ class XorInst : public User
     XorInst(Operand _A, std::string opcode, Operand _B);
     void print()final;
 };
-
-void RSUW (Operand A, User* B, int num);

--- a/lib/BaseCFG.cpp
+++ b/lib/BaseCFG.cpp
@@ -180,6 +180,15 @@ bool User::HasSideEffect()
 
 Value *User::GetDef() { return dynamic_cast<Value *>(this); }
 
+// change uselist[num] to val while manage use-def relation
+void User::RSUW(int num,Operand val){
+  auto& uselist=Getuselist();
+  assert(0<=num&&num<uselist.size()&&"Invalid Location!");
+  uselist[num]->usee=val;
+  uselist[num]->RemoveFromUserList(this);
+  val->add_user(uselist[num].get());
+}
+
 ConstantData::ConstantData(Type *_tp) : Value(_tp) {}
 
 ConstIRBoolean::ConstIRBoolean(bool _val)

--- a/lib/BaseCFG.hpp
+++ b/lib/BaseCFG.hpp
@@ -113,6 +113,7 @@ class User:public Value,public list_node<BasicBlock,User>
     bool Alive = false;
     bool IsTerminateInst();
     bool HasSideEffect();
+    void RSUW(int,Operand);
 };
 
 class ConstantData:public Value


### PR DESCRIPTION
close #8  

Assum B is a user, and we want to change its operand whose index is num to A while maintain its use-def chain. Call `B->RSUW(num,A)`. Move this declaration to BaseCFG.hpp.